### PR TITLE
makes project compile without changing the header files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 
 *.xcuserstate
+*.xcuserdatad
+

--- a/Browser.xcodeproj/project.pbxproj
+++ b/Browser.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		B002B86D1BAE420500C744AF /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B002B86C1BAE420500C744AF /* ViewController.m */; };
 		B002B8701BAE420500C744AF /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B002B86E1BAE420500C744AF /* Main.storyboard */; };
 		B002B8721BAE420500C744AF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B002B8711BAE420500C744AF /* Assets.xcassets */; };
-		B0F6B4621BAEBF9900E2F26B /* README.mdown in Sources */ = {isa = PBXBuildFile; fileRef = B0F6B4611BAEBF9900E2F26B /* README.mdown */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,10 +41,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		B002B8591BAE420500C744AF = {
+		70BF2D911ED047720091A3C0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 				3AEF5B7E1BCBCC7400891762 /* UIKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B002B8591BAE420500C744AF = {
+			isa = PBXGroup;
+			children = (
 				B0F6B4611BAEBF9900E2F26B /* README.mdown */,
 				B002B8641BAE420500C744AF /* Browser */,
 				B002B8631BAE420500C744AF /* Products */,
@@ -68,6 +74,7 @@
 				B002B86B1BAE420500C744AF /* ViewController.h */,
 				B002B86C1BAE420500C744AF /* ViewController.m */,
 				B002B8651BAE420500C744AF /* Supporting Files */,
+				70BF2D911ED047720091A3C0 /* Frameworks */,
 			);
 			path = Browser;
 			sourceTree = "<group>";
@@ -110,7 +117,7 @@
 		B002B85A1BAE420500C744AF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = "High Caffeine Content";
 				TargetAttributes = {
 					B002B8611BAE420500C744AF = {
@@ -172,7 +179,6 @@
 			files = (
 				B002B86D1BAE420500C744AF /* ViewController.m in Sources */,
 				B002B86A1BAE420500C744AF /* AppDelegate.m in Sources */,
-				B0F6B4621BAEBF9900E2F26B /* README.mdown in Sources */,
 				B002B8671BAE420500C744AF /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -204,8 +210,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
@@ -247,8 +255,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;

--- a/Browser/AppDelegate.h
+++ b/Browser/AppDelegate.h
@@ -7,12 +7,10 @@
 //  Copyright © 2015 High Caffeine Content. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
 @property (strong, nonatomic) UIWindow *window;
 
-
 @end
-

--- a/Browser/AppDelegate.m
+++ b/Browser/AppDelegate.m
@@ -15,7 +15,6 @@
 
 @implementation AppDelegate
 
-
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 	// Override point for customization after application launch.
     if ([[NSUserDefaults standardUserDefaults] boolForKey:@"MobileMode"]) {

--- a/Browser/ViewController.h
+++ b/Browser/ViewController.h
@@ -7,11 +7,9 @@
 //  Copyright © 2015 High Caffeine Content. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
-#import <GameKit/GameKit.h>
+@import UIKit;
+@import GameKit;
 
-@interface ViewController : GCEventViewController  <UIWebViewDelegate>
-
+@interface ViewController : GCEventViewController
 
 @end
-

--- a/README.mdown
+++ b/README.mdown
@@ -2,22 +2,6 @@ tvOS Browser
 =============
 
 Web browser for tvOS using private API (aka UIWebView).
-You'll need to redefine the following in Availability.h to build successfully.
-```
-Availability.h for the AppleTV is located in Xcode>Contents>Developer>Platforms>AppleTVOS.platform>Developer>SDKs>AppleTVOS.sdk>usr>include
-Availability.h for the AppleTV Simulator is located in Xcode>Contents>Developer>Platforms>AppleTVSimulator.platform>Developer>SDKs>AppleTVSimulator.sdk>usr>include
-```
-Change:
-```
-#define __TVOS_UNAVAILABLE                    __OS_AVAILABILITY(tvos,unavailable)
-#define __TVOS_PROHIBITED                     __OS_AVAILABILITY(tvos,unavailable)
-```
-To:
-```
-#define __TVOS_UNAVAILABLE_NOTQUITE                    __OS_AVAILABILITY(tvos,unavailable)
-#define __TVOS_PROHIBITED_NOTQUITE                     __OS_AVAILABILITY(tvos,unavailable)
-```
-Do this for Availability.h for both simulator and device if you want to run it on the real hardware.
 
 How to Use tvOSBrowser
 =============


### PR DESCRIPTION
This pull request removes the need for patching header files by changing the webViews reference from type `UIWebView` to type `id`. In Objc-C you can initiate an object with a class name and send an object of type `id` any kind of message. By changing the init method to

    [[NSClassFromString(@"UIWebView") alloc] initWithFrame:…]

and changing the access to the properties to message calls I could eliminate the compiler warnings and remove the need to patch the header files.

I also updated the project settings and did some cleanup on the code.