### PR TITLE
Fix a crash for "WebCoreNSURLSessionTaskTransactionMetrics _privacyStance]: unrecognized selector sent to instance"

### DIFF
--- a/_Project/Browser.xcodeproj/project.pbxproj
+++ b/_Project/Browser.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3A2A7C2021E784760083CB13 /* resize-arrows.png in Resources */ = {isa = PBXBuildFile; fileRef = 3A2A7C1F21E784760083CB13 /* resize-arrows.png */; };
 		9675E1FC20855F6500A4A84A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9675E1FB20855F6500A4A84A /* Foundation.framework */; };
 		9675E1FF20857AEF00A4A84A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9675E1FE20857AEF00A4A84A /* UIKit.framework */; };
+		A18BD0D329787BD00054E225 /* WebCoreNSURLSessionTaskTransactionMetrics+AddPrivacyStance.m in Sources */ = {isa = PBXBuildFile; fileRef = A18BD0D229787BD00054E225 /* WebCoreNSURLSessionTaskTransactionMetrics+AddPrivacyStance.m */; };
 		B002B8671BAE420500C744AF /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = B002B8661BAE420500C744AF /* main.m */; };
 		B002B86A1BAE420500C744AF /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = B002B8691BAE420500C744AF /* AppDelegate.m */; };
 		B002B86D1BAE420500C744AF /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B002B86C1BAE420500C744AF /* ViewController.m */; };
@@ -35,6 +36,7 @@
 		3A2A7C1F21E784760083CB13 /* resize-arrows.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "resize-arrows.png"; sourceTree = "<group>"; };
 		9675E1FB20855F6500A4A84A /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		9675E1FE20857AEF00A4A84A /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		A18BD0D229787BD00054E225 /* WebCoreNSURLSessionTaskTransactionMetrics+AddPrivacyStance.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WebCoreNSURLSessionTaskTransactionMetrics+AddPrivacyStance.m"; sourceTree = "<group>"; };
 		B002B8621BAE420500C744AF /* Browser.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Browser.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B002B8661BAE420500C744AF /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		B002B8681BAE420500C744AF /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -106,6 +108,7 @@
 		B002B8641BAE420500C744AF /* Browser */ = {
 			isa = PBXGroup;
 			children = (
+				A18BD0D229787BD00054E225 /* WebCoreNSURLSessionTaskTransactionMetrics+AddPrivacyStance.m */,
 				B002B8681BAE420500C744AF /* AppDelegate.h */,
 				B002B8691BAE420500C744AF /* AppDelegate.m */,
 				B002B86B1BAE420500C744AF /* ViewController.h */,
@@ -225,6 +228,7 @@
 			files = (
 				B002B86D1BAE420500C744AF /* ViewController.m in Sources */,
 				B002B86A1BAE420500C744AF /* AppDelegate.m in Sources */,
+				A18BD0D329787BD00054E225 /* WebCoreNSURLSessionTaskTransactionMetrics+AddPrivacyStance.m in Sources */,
 				B002B8671BAE420500C744AF /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/_Project/Browser/WebCoreNSURLSessionTaskTransactionMetrics+AddPrivacyStance.m
+++ b/_Project/Browser/WebCoreNSURLSessionTaskTransactionMetrics+AddPrivacyStance.m
@@ -13,7 +13,6 @@
 #import <objc/runtime.h>
 #import <Foundation/Foundation.h>
 
-
 int privacyStanceGetter(id self, SEL _cmd) {
     return 0;
 }
@@ -29,9 +28,7 @@ int privacyStanceGetter(id self, SEL _cmd) {
         if (class_getInstanceMethod(class, NSSelectorFromString(@"_privacyStance")) != nil) {
             return;
         }
-        
-        objc_property_attribute_t attrs[] = { };
-        class_addProperty(class, "privacyStance", attrs, 0);
+
         class_addMethod(class, NSSelectorFromString(@"_privacyStance"), (IMP)privacyStanceGetter, "@@:");
     });
 }

--- a/_Project/Browser/WebCoreNSURLSessionTaskTransactionMetrics+AddPrivacyStance.m
+++ b/_Project/Browser/WebCoreNSURLSessionTaskTransactionMetrics+AddPrivacyStance.m
@@ -1,0 +1,39 @@
+//
+//  WebCoreNSURLSessionTaskTransactionMetrics+AddPrivacyStance.m
+//  Browser
+//
+//  Created by Povilas Staskus on 2023-01-18.
+//  Copyright © 2023 High Caffeine Content. All rights reserved.
+//
+
+// A workaround fix for a crash happening at runtime
+// WebCoreNSURLSessionTaskTransactionMetrics is expected to have _privacyStance although it does not exist
+// https://github.com/jvanakker/tvOSBrowser/issues/54
+
+#import <objc/runtime.h>
+#import <Foundation/Foundation.h>
+
+
+int privacyStanceGetter(id self, SEL _cmd) {
+    return 0;
+}
+
+@implementation NSObject (WebCoreNSURLSessionTaskTransactionMetrics)
+
++ (void)load {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        Class class = objc_getClass("WebCoreNSURLSessionTaskTransactionMetrics");
+        
+        /// Do not attempt to add privacyStance if it already exists
+        if (class_getInstanceMethod(class, NSSelectorFromString(@"_privacyStance")) != nil) {
+            return;
+        }
+        
+        objc_property_attribute_t attrs[] = { };
+        class_addProperty(class, "privacyStance", attrs, 0);
+        class_addMethod(class, NSSelectorFromString(@"_privacyStance"), (IMP)privacyStanceGetter, "@@:");
+    });
+}
+
+@end


### PR DESCRIPTION
Fixes: #54

Due to issues with WebKit and tvOS, `[WebCoreNSURLSessionTaskTransactionMetrics _privacyStance]: unrecognized selector sent to instance` crash anytime the video is played.

### Solution

Add a dummy `_privacyStance` getter at runtime which returns 0. [The system expects a value from nw_connection_privacy_stance_t  enum](https://github.com/WebKit/WebKit/blob/b904d8ac17fff03be6469d9832b452107642b025/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h#L132) where 0 means `nw_connection_privacy_stance_unknown`.

Let me know if you have any questions, thanks!